### PR TITLE
[DEV ] Adding a qc report report workflow

### DIFF
--- a/conf/conda.config
+++ b/conf/conda.config
@@ -3,4 +3,14 @@ process {
     ".*" {
         conda = 'bioconda::mtbseq=1.0.3'
     }
+
+    withName:
+    'FASTQC' {
+        conda = 'bioconda::fastqc=0.11.9'
+    }
+
+    withName:
+    'MULTIQC' {
+        conda = 'bioconda::multiqc=1.9'
+    }
 }

--- a/conf/docker.config
+++ b/conf/docker.config
@@ -5,4 +5,15 @@ process {
     ".*" {
         container = 'quay.io/biocontainers/mtbseq:1.0.3--pl526_1'
     }
+
+    withName:
+    'FASTQC' {
+        container = 'quay.io/biocontainers/fastqc:0.11.9--0'
+    }
+
+    withName:
+    'MULTIQC' {
+        container = 'quay.io/biocontainers/multiqc:1.9--pyh9f0ad1d_0'
+    }
+
 }

--- a/conf/global_params.config
+++ b/conf/global_params.config
@@ -99,7 +99,7 @@ categories = "${projectDir}/data/references/cat/MTB_Gene_Categories.txt"
 // This OPTION specifies a file for base quality recalibration. The list must be in VCF format and should contain known SNPs.
 basecalib = "${projectDir}/data/references/res/MTB_Base_Calibration_List.vcf"
 
-
+skip_qc =  false
 
 
 

--- a/conf/global_params.config
+++ b/conf/global_params.config
@@ -333,3 +333,15 @@ RENAME_FILES {
     save_mode = 'copy'
     should_publish = true
 }
+
+FASTQC {
+    results_dir = "${params.outdir}/fastqc"
+    save_mode = 'copy'
+    should_publish = true
+}
+
+MULTIQC {
+    results_dir = "${params.outdir}/multiqc"
+    save_mode = 'copy'
+    should_publish = true
+}

--- a/modules/utils/fastqc.nf
+++ b/modules/utils/fastqc.nf
@@ -14,7 +14,7 @@ process FASTQC {
     script:
 
     """
-    fastqc *fastq*
+    fastqc *fastq* -t ${task.cpus}
     """
 
     stub:

--- a/modules/utils/fastqc.nf
+++ b/modules/utils/fastqc.nf
@@ -1,0 +1,27 @@
+nextflow.enable.dsl = 2
+
+process FASTQC {
+    tag "${genomeName}"
+    publishDir params.results_dir, mode: params.save_mode, enabled: params.should_publish
+
+    input:
+    tuple val(genomeName), path(genomeReads)
+
+    output:
+    tuple path('*.html'), path('*.zip')
+
+
+    script:
+
+    """
+    fastqc *fastq*
+    """
+
+    stub:
+
+    """
+    echo "fastqc *fastq*"
+    touch ${genomeName}.html
+    touch ${genomeName}.zip
+    """
+}

--- a/modules/utils/multiqc.nf
+++ b/modules/utils/multiqc.nf
@@ -1,0 +1,23 @@
+nextflow.enable.dsl = 2
+
+process MULTIQC {
+    publishDir params.results_dir, mode: params.save_mode, enabled: params.should_publish
+
+    input:
+    path("*")
+
+    output:
+    tuple path("multiqc_data"), path("multiqc_report.html)
+
+    script:
+
+    """
+    multiqc .
+    """
+
+    stub:
+    """
+    mkdir multiqc_data
+    touch multiqc_report.html
+    """
+}

--- a/workflows/qc_reports.nf
+++ b/workflows/qc_reports.nf
@@ -1,0 +1,15 @@
+nextflow.enable.dsl = 2
+
+include { FASTQC } from "../modules/utils/fastqc.nf" addParams (params.FASTQC)
+include { MULTIQC } from "../modules/utils/multiqc.nf" addParams (params.MULTIQC)
+
+
+workflow QC_REPORTS {
+    take:
+        reads_ch
+
+    main:
+         FASTQC(reads_ch)
+         MULTIQC(FASTQC.out.collect())
+
+}


### PR DESCRIPTION
Hey there :wave:,

As requested on #55, I took some time to add the fastqc and multiqc modules and also implement  them in a way that respect user choices. I considered 3 possibilities:

1. The user uses the workflow as normal, so the program runs qc report by default
2. The user uses the workflow but doesn't want qc report, so should use `--skip_qc true` on CLI or modify the standard param on the config file.
3. The user only wants to run qc_report, so it can use `-entry QUALITY_CONTROL` on CLI command

A param based decision looked the most intuitive and user-friendly option, but we can discuss the implementation as the base work (module addition and configuration) is already done!

Feel free to discuss those changes with me, I'm available to make any requested change and listen your thoughts about it! 

Hope we have a merge!
Kindly, Davi