### PR TITLE
[MAINTENANCE] Adding a test workflow and updating the `Makefile`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,4 @@ results*
 *.nextflow*
 
 conda_envs/mtbseq-nf-env*
-conda_envs/xbs-nf-env*
 containers/**/*yml

--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,6 @@ data/full_data
 results*
 *.nextflow*
 
+conda_envs/mtbseq-nf-env*
 conda_envs/xbs-nf-env*
 containers/**/*yml

--- a/Makefile
+++ b/Makefile
@@ -7,5 +7,4 @@ run_dev:
 	nextflow run main.nf -profile dev -resume -with-tower
 
 run_test:
-	nextflow run main.nf -params-file params/test.yml -entry TEST -resume -profile conda
-	nextflow run main.nf -params-file params/test.yml -entry TEST -resume -profile docker
+	nextflow run main.nf -params-file params/test.yml -entry TEST -resume -profile standard,docker

--- a/Makefile
+++ b/Makefile
@@ -7,4 +7,5 @@ run_dev:
 	nextflow run main.nf -profile dev -resume -with-tower
 
 run_test:
-	nextflow run main.nf -params-file params/standard.yml -entry TEST -resume
+	nextflow run main.nf -params-file params/test.yml -entry TEST -resume -profile conda
+	nextflow run main.nf -params-file params/test.yml -entry TEST -resume -profile docker

--- a/main.nf
+++ b/main.nf
@@ -96,5 +96,20 @@ workflow {
 
 workflow TEST {
 
+reads_ch = Channel.fromSRA(params.genomeIds, cache: true, apiKey: params.ncbi_api_key)
+
+PARALLEL_ANALYSIS(reads_ch,
+                  [params.resilist,
+                    params.intregions,
+                    params.categories,
+                    params.basecalib])
+
+BATCH_ANALYSIS(reads_ch,
+               [params.resilist,
+                 params.intregions,
+                 params.categories,
+                 params.basecalib])
+
+
 
 }

--- a/params/test.yml
+++ b/params/test.yml
@@ -3,6 +3,6 @@ genomeIds:
   - "ERR841440"
   - "ERR1193883"
 
-outdir: "./output"
+outdir: "./test_output"
 
-ncbi_api_key: "FIX ME"
+ncbi_api_key: "b6d95ddb1bbd179bf9408c2726dba5ddfe09"

--- a/params/test.yml
+++ b/params/test.yml
@@ -1,6 +1,6 @@
 genomeIds:
-  - "ERR841438"
-  - "ERR841440"
+  - "ERR037481"
+  - "ERR216945"
   - "ERR1193883"
 
 outdir: "./test_output"

--- a/params/test.yml
+++ b/params/test.yml
@@ -1,0 +1,8 @@
+genomeIds:
+  - "ERR841438"
+  - "ERR841440"
+  - "ERR1193883"
+
+outdir: "./output"
+
+ncbi_api_key: "FIX ME"

--- a/params/test.yml
+++ b/params/test.yml
@@ -5,4 +5,4 @@ genomeIds:
 
 outdir: "./test_output"
 
-ncbi_api_key: "b6d95ddb1bbd179bf9408c2726dba5ddfe09"
+ncbi_api_key: "API_KEY"


### PR DESCRIPTION
hey :wave:, as a small maintenance I tried to update the `TEST` workflow and updated the `Makefile` so we can run `make run_test` and test the complete run with `docker` and `conda`. 

This might be an initial solution, but after the v1.0.0 release we can discuss an implementation of pytests and md5 checking. What do you think about it? I tested it here and apparently, it's working well.

Feel free to add your thoughts on the comments, I'll available to make any requested changes, we can also discuss the makefile implementation as this still very initial.