### PR TITLE
[FIX] Adding specific tag to conda recipe

### DIFF
--- a/conda_envs/mtbseq-nf-env.yml
+++ b/conda_envs/mtbseq-nf-env.yml
@@ -4,6 +4,6 @@ channels:
   - bioconda
 dependencies:
   - bioconda::mtbseq=1.0.3
-  - bioconda/linux-64::gatk=3.8.0
+  - bioconda/linux-64::gatk=3.8.0=py36_0
   - bioconda::fastqc=0.11.9
   - bioconda::multiqc=1.9


### PR DESCRIPTION
hey :wave:, after our pair debugging we found some inconsistencies when using the gatk 3.8.0. So I'm suggesting  the specific usage of the `py36_0` label, as the `py36_4` requires gatk3-register and may cause inconsistencies into the run.

Feel free to add your thoughts into this pr comments sessions!!

This pr somewhat relates to #59 and #58 

Kindly, Davi