### PR TITLE
[Fix] Preventing workflows from caching the `samples.tsv` for cohort steps

### DIFF
--- a/workflows/batch_analysis.nf
+++ b/workflows/batch_analysis.nf
@@ -19,7 +19,7 @@ workflow BATCH_ANALYSIS {
                 .collect()
                 .flatten()
                 .map { n -> "$n" + "\t" + "${params.library_name}" + "\n" }
-                .collectFile(name: params.cohort_tsv, newLine: false, storeDir: "${params.outdir}")
+                .collectFile(name: params.cohort_tsv, newLine: false, storeDir: "${params.outdir}", cache: false)
 
         RENAME_FILES(reads_ch)
 

--- a/workflows/cohort_analysis.nf
+++ b/workflows/cohort_analysis.nf
@@ -15,7 +15,7 @@ workflow COHORT_ANALYSIS {
         samples_tsv_file = genome_names
                 .collect()
                 .flatten().map { n -> "$n" + "\t" + "${params.library_name}" + "\n" }
-                .collectFile(name: params.cohort_tsv, newLine: false, storeDir: "${params.outdir}")
+                .collectFile(name: params.cohort_tsv, newLine: false, storeDir: "${params.outdir}", cache: false)
 
         TBJOIN(position_variants.collect(),
                position_tables.collect(),


### PR DESCRIPTION
Hey :wave:, on my latest runs I firstly run 3 samples completely and after a successful run I started a new run with 71 samples using `-resume`, Interestingly the `samples.tsv` was kept the same and the cohort only run for 3 samples.

The samples.tsv for 3 samples only had information for 3 samples, and after resuming the sample sample.tsv was used, so the other 68 samples where ignored by mtbseq as they weren't mentioned on the samples.tsv file.

As a solution for this, I added `cache: false` to the `collectFile` operator, so the file will be generated again on every run. 

Feel free to add your thoughts on the comments session, I'm available to discuss and make any requested modification.

Kindly, Davi